### PR TITLE
Fix links in the footer

### DIFF
--- a/layout.html.twig
+++ b/layout.html.twig
@@ -124,7 +124,7 @@
                             <h1><i class="icon-bar-chart"></i></h1>
                             <div>
                                 <ul>
-                                    <li><a href="">Class Hierarchy Diagram</a></li>
+                                    <li><a href="{{ path('graphs/class.html') }}">Class Hierarchy Diagram</a></li>
                                 </ul>
                             </div>
                         </section>
@@ -133,8 +133,8 @@
                             <h1><i class="icon-pushpin"></i></h1>
                             <div>
                                 <ul>
-                                    <li><a href="">Errors</a></li>
-                                    <li><a href="">Markers</a></li>
+                                    <li><a href="{{ path('reports/errors.html') }}">Errors</a></li>
+                                    <li><a href="{{ path('reports/markers.html') }}">Markers</a></li>
                                 </ul>
                             </div>
                         </section>


### PR DESCRIPTION
There are three links in the footer that point to the current
page right now. They are:
1. Class Hierarchy Diagram
2. Errors
3. Markers

Fix these links so that they point to the correct pages instead.
1. Class Hierarchy Diagram should point to graphs/class.html
2. Errors should point to reports/errors.html
3. Markers should point to reports/markers.html

Fixes phpDocumentor/template.clean#5
