### PR TITLE
CentOS executes copied Source

### DIFF
--- a/htaccess.dist
+++ b/htaccess.dist
@@ -1,0 +1,5 @@
+# Fixes a vulnerability in CentOS: http://stackoverflow.com/questions/20533279/prevent-php-from-parsing-non-php-files-such-as-somefile-php-txt
+<FilesMatch \.php\.txt$>
+    RemoveHandler .php
+    ForceType text/plain
+</FilesMatch>

--- a/template.xml
+++ b/template.xml
@@ -15,6 +15,7 @@
       </ifModule>
   ]]></description>
   <transformations>
+    <transformation query="copy" writer="FileIo" source="templates/clean/htaccess.dist" artifact=".htaccess"/>
     <transformation query="copy" writer="FileIo" source="templates/clean/images" artifact="images"/>
     <transformation query="copy" writer="FileIo" source="templates/clean/css" artifact="css"/>
     <transformation query="copy" writer="FileIo" source="templates/clean/js" artifact="js"/>


### PR DESCRIPTION
CentOS by default executes any file containing an extension part with
`.php` in it. Thus also the `.php.txt` files that are used to show the
source code.

This commit adds a .htaccess file that disables that behaviour and as
such fixes https://github.com/phpDocumentor/phpDocumentor2/issues/1157
