### PR TITLE
Fix phpDocumentor/phpDocumentor2#982: Clean template: Left sidebar does not size well on Android

### DIFF
--- a/css/template.css
+++ b/css/template.css
@@ -396,14 +396,19 @@ body .modal {
         background-color: white;
     }
 
-    .footer-sections h1 {
+    .footer-sections .span4 h1 {
         color: #ccccd9;
+        margin-top: 0;
     }
 
     .detailsbar {
         background-color: white;
         color: #333;
         border: none;
+    }
+
+    .row-fluid .span2 {
+        width: 100%;
     }
 }
 


### PR DESCRIPTION
Also fixed the footer icon positioning on Android while I was there - they were up too high and since they are white, half the icon was not visible against the white background.

phpDocumentor/phpDocumentor2#982
